### PR TITLE
Add simple browser text adventure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# survive
+# Survive
+
+Simple browser-based text adventure. Open `index.html` in your browser to begin. Create a character name and continue your adventure. Progress is stored in `localStorage` so you can return later and continue playing.

--- a/game.html
+++ b/game.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Survive - Game</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1 id="welcome"></h1>
+    <div id="text"></div>
+    <div id="choices"></div>
+    <button id="restart" onclick="restart()" style="display:none">Restart</button>
+    <script src="game.js"></script>
+</body>
+</html>

--- a/game.js
+++ b/game.js
@@ -1,0 +1,78 @@
+const scenes = {
+    start: {
+        text: `You wake up in a dark forest. A path splits north and east.`,
+        choices: [
+            { label: 'Go north', next: 'north' },
+            { label: 'Go east', next: 'east' }
+        ]
+    },
+    north: {
+        text: `A hungry wolf blocks your way.`,
+        choices: [
+            { label: 'Fight', next: 'fight' },
+            { label: 'Run', next: 'run' }
+        ]
+    },
+    east: {
+        text: `You find a quiet cabin. Inside is food and a bed.`,
+        choices: [
+            { label: 'Rest', next: 'rest' },
+            { label: 'Keep moving', next: 'run' }
+        ]
+    },
+    fight: {
+        text: `You defeated the wolf but were badly wounded. You reach a village and recover.`,
+        end: 'You survive to see another day!'
+    },
+    run: {
+        text: `You get lost and eventually collapse from exhaustion.`,
+        end: 'Your adventure ends here.'
+    },
+    rest: {
+        text: `While resting, you dream of a better life. When you awake, the path is clear.`,
+        end: 'A peaceful ending awaits you.'
+    }
+};
+
+function showScene(id) {
+    const scene = scenes[id];
+    const user = JSON.parse(localStorage.getItem('surviveUser'));
+    if (!scene) return;
+    user.scene = id;
+    localStorage.setItem('surviveUser', JSON.stringify(user));
+
+    document.getElementById('welcome').textContent = `Welcome, ${user.name}`;
+    document.getElementById('text').textContent = scene.text;
+    const choicesDiv = document.getElementById('choices');
+    choicesDiv.innerHTML = '';
+
+    if (scene.end) {
+        const endP = document.createElement('p');
+        endP.textContent = scene.end;
+        choicesDiv.appendChild(endP);
+        document.getElementById('restart').style.display = 'block';
+        return;
+    }
+
+    scene.choices.forEach(choice => {
+        const btn = document.createElement('button');
+        btn.textContent = choice.label;
+        btn.onclick = () => showScene(choice.next);
+        choicesDiv.appendChild(btn);
+    });
+}
+
+function restart() {
+    localStorage.removeItem('surviveUser');
+    window.location.href = 'index.html';
+}
+
+window.onload = () => {
+    const userData = localStorage.getItem('surviveUser');
+    if (!userData) {
+        window.location.href = 'index.html';
+        return;
+    }
+    const user = JSON.parse(userData);
+    showScene(user.scene || 'start');
+};

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Survive - Sign Up</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Survive</h1>
+    <div id="auth">
+        <h2>Sign Up / Log In</h2>
+        <input id="name" placeholder="Character Name" />
+        <button onclick="startGame()">Enter</button>
+    </div>
+    <script src="index.js"></script>
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,14 @@
+function startGame() {
+    const name = document.getElementById('name').value.trim();
+    if (!name) return alert('Enter a name');
+    localStorage.setItem('surviveUser', JSON.stringify({ name, scene: 'start' }));
+    window.location.href = 'game.html';
+}
+
+window.onload = () => {
+    const saved = localStorage.getItem('surviveUser');
+    if (saved) {
+        // Auto continue to game if already registered
+        window.location.href = 'game.html';
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "survive",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,3 @@
+body { font-family: sans-serif; margin: 20px; background:#f5f5f5; }
+button { margin: 5px; }
+#text { margin: 20px 0; }


### PR DESCRIPTION
## Summary
- create landing page for signup
- build game logic that stores progress in localStorage
- add minimal CSS styling
- add package.json with no-op test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68454d706d788323a67729f074ffcbbe