### PR TITLE
Add language, gender and stats system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Survive
 
-Simple browser-based text adventure. Open `index.html` in your browser to begin. Create a character name and continue your adventure. Progress is stored in `localStorage` so you can return later and continue playing.
+Simple browser-based text adventure. Open `index.html` in your browser to begin. Kaydınızı oluştururken dil (varsayılan Türkçe) ve cinsiyet seçimi yapabilirsiniz. Oyun sırasında para, güç, sosyal çevre ve açlık gibi istatistikler kararlarınıza göre değişir. İlerleme `localStorage`'da saklanır, böylece daha sonra devam edebilirsiniz.

--- a/game.html
+++ b/game.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="tr">
 <head>
     <meta charset="UTF-8">
     <title>Survive - Game</title>
@@ -7,7 +7,9 @@
 </head>
 <body>
     <h1 id="welcome"></h1>
+    <div id="image" style="font-size:50px"></div>
     <div id="text"></div>
+    <div id="stats"></div>
     <div id="choices"></div>
     <button id="restart" onclick="restart()" style="display:none">Restart</button>
     <script src="game.js"></script>

--- a/game.js
+++ b/game.js
@@ -1,54 +1,121 @@
+const translations = {
+    tr: {
+        start_text: 'Karanlık bir ormanda uyanıyorsun. Kuzey ve doğu yönünde yollar var.',
+        start_choice_north: 'Kuzeye git',
+        start_choice_east: 'Doğuya git',
+        north_text: 'Aç bir kurt yolunu kesiyor.',
+        north_choice_fight: 'Savaş',
+        north_choice_run: 'Kaç',
+        east_text: 'Sessiz bir kulübe buluyorsun. İçeride yiyecek ve yatak var.',
+        east_choice_rest: 'Dinlen',
+        east_choice_keep_moving: 'Yola devam et',
+        fight_text: 'Kurdu yendin ama ağır yaralandın. Bir köye ulaşıp iyileştin.',
+        fight_end: 'Bir başka günü görmeyi başardın!',
+        run_text: 'Kayboldun ve yorgunluktan yere yığıldın.',
+        run_end: 'Maceran burada son buldu.',
+        rest_text: 'Dinlenirken daha iyi bir yaşam hayal ediyorsun. Uyandığında yol açık.',
+        rest_end: 'Huzurlu bir son seni bekliyor.',
+        stat_money: 'Para',
+        stat_power: 'Güç',
+        stat_social: 'Sosyal Çevre',
+        stat_hunger: 'Açlık',
+        welcome: 'Hoş geldin, {name}'
+    },
+    en: {
+        start_text: 'You wake up in a dark forest. A path splits north and east.',
+        start_choice_north: 'Go north',
+        start_choice_east: 'Go east',
+        north_text: 'A hungry wolf blocks your way.',
+        north_choice_fight: 'Fight',
+        north_choice_run: 'Run',
+        east_text: 'You find a quiet cabin. Inside is food and a bed.',
+        east_choice_rest: 'Rest',
+        east_choice_keep_moving: 'Keep moving',
+        fight_text: 'You defeated the wolf but were badly wounded. You reach a village and recover.',
+        fight_end: 'You survive to see another day!',
+        run_text: 'You get lost and eventually collapse from exhaustion.',
+        run_end: 'Your adventure ends here.',
+        rest_text: 'While resting, you dream of a better life. When you awake, the path is clear.',
+        rest_end: 'A peaceful ending awaits you.',
+        stat_money: 'Money',
+        stat_power: 'Power',
+        stat_social: 'Social Circle',
+        stat_hunger: 'Hunger',
+        welcome: 'Welcome, {name}'
+    }
+};
+
+function t(lang, key) {
+    return translations[lang][key] || translations['tr'][key] || key;
+}
+
 const scenes = {
     start: {
-        text: `You wake up in a dark forest. A path splits north and east.`,
+        text: 'start_text',
+        img: '🌲',
         choices: [
-            { label: 'Go north', next: 'north' },
-            { label: 'Go east', next: 'east' }
+            { label: 'start_choice_north', next: 'north', effects: { hunger: 1 } },
+            { label: 'start_choice_east', next: 'east' }
         ]
     },
     north: {
-        text: `A hungry wolf blocks your way.`,
+        text: 'north_text',
+        img: '🐺',
         choices: [
-            { label: 'Fight', next: 'fight' },
-            { label: 'Run', next: 'run' }
+            { label: 'north_choice_fight', next: 'fight', effects: { power: -2, hunger: 2 } },
+            { label: 'north_choice_run', next: 'run', effects: { hunger: 3 } }
         ]
     },
     east: {
-        text: `You find a quiet cabin. Inside is food and a bed.`,
+        text: 'east_text',
+        img: '🏠',
         choices: [
-            { label: 'Rest', next: 'rest' },
-            { label: 'Keep moving', next: 'run' }
+            { label: 'east_choice_rest', next: 'rest', effects: { hunger: -3, social: 1 } },
+            { label: 'east_choice_keep_moving', next: 'run', effects: { hunger: 2 } }
         ]
     },
     fight: {
-        text: `You defeated the wolf but were badly wounded. You reach a village and recover.`,
-        end: 'You survive to see another day!'
+        text: 'fight_text',
+        img: '⚔️',
+        end: 'fight_end'
     },
     run: {
-        text: `You get lost and eventually collapse from exhaustion.`,
-        end: 'Your adventure ends here.'
+        text: 'run_text',
+        img: '🏃',
+        end: 'run_end'
     },
     rest: {
-        text: `While resting, you dream of a better life. When you awake, the path is clear.`,
-        end: 'A peaceful ending awaits you.'
+        text: 'rest_text',
+        img: '🛏️',
+        end: 'rest_end'
     }
 };
 
 function showScene(id) {
-    const scene = scenes[id];
     const user = JSON.parse(localStorage.getItem('surviveUser'));
+    const lang = user.lang || 'tr';
+    const scene = scenes[id];
     if (!scene) return;
     user.scene = id;
     localStorage.setItem('surviveUser', JSON.stringify(user));
 
-    document.getElementById('welcome').textContent = `Welcome, ${user.name}`;
-    document.getElementById('text').textContent = scene.text;
+    document.getElementById('welcome').textContent = t(lang, 'welcome').replace('{name}', user.name);
+    document.getElementById('text').textContent = t(lang, scene.text);
+    document.getElementById('image').textContent = scene.img || '';
+
+    const statsDiv = document.getElementById('stats');
+    statsDiv.innerHTML =
+        `<span>${t(lang, 'stat_money')}: ${user.stats.money}</span>` +
+        `<span>${t(lang, 'stat_power')}: ${user.stats.power}</span>` +
+        `<span>${t(lang, 'stat_social')}: ${user.stats.social}</span>` +
+        `<span>${t(lang, 'stat_hunger')}: ${user.stats.hunger}</span>`;
+
     const choicesDiv = document.getElementById('choices');
     choicesDiv.innerHTML = '';
 
     if (scene.end) {
         const endP = document.createElement('p');
-        endP.textContent = scene.end;
+        endP.textContent = t(lang, scene.end);
         choicesDiv.appendChild(endP);
         document.getElementById('restart').style.display = 'block';
         return;
@@ -56,8 +123,17 @@ function showScene(id) {
 
     scene.choices.forEach(choice => {
         const btn = document.createElement('button');
-        btn.textContent = choice.label;
-        btn.onclick = () => showScene(choice.next);
+        btn.textContent = t(lang, choice.label);
+        btn.onclick = () => {
+            if (choice.effects) {
+                for (const k in choice.effects) {
+                    user.stats[k] += choice.effects[k];
+                    if (user.stats[k] < 0) user.stats[k] = 0;
+                }
+                localStorage.setItem('surviveUser', JSON.stringify(user));
+            }
+            showScene(choice.next);
+        };
         choicesDiv.appendChild(btn);
     });
 }
@@ -74,5 +150,6 @@ window.onload = () => {
         return;
     }
     const user = JSON.parse(userData);
+    document.documentElement.lang = user.lang || 'tr';
     showScene(user.scene || 'start');
 };

--- a/index.html
+++ b/index.html
@@ -1,16 +1,30 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="tr">
 <head>
     <meta charset="UTF-8">
-    <title>Survive - Sign Up</title>
+    <title>Survive - Kayıt</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <h1>Survive</h1>
     <div id="auth">
-        <h2>Sign Up / Log In</h2>
-        <input id="name" placeholder="Character Name" />
-        <button onclick="startGame()">Enter</button>
+        <h2>Kayıt Ol / Giriş Yap</h2>
+        <input id="name" placeholder="Karakter Adı" />
+        <div>
+            <label for="gender">Cinsiyet: </label>
+            <select id="gender">
+                <option value="male">Erkek</option>
+                <option value="female">Kadın</option>
+            </select>
+        </div>
+        <div>
+            <label for="lang">Dil: </label>
+            <select id="lang">
+                <option value="tr">Türkçe</option>
+                <option value="en">English</option>
+            </select>
+        </div>
+        <button onclick="startGame()">Başla</button>
     </div>
     <script src="index.js"></script>
 </body>

--- a/index.js
+++ b/index.js
@@ -1,7 +1,16 @@
 function startGame() {
     const name = document.getElementById('name').value.trim();
     if (!name) return alert('Enter a name');
-    localStorage.setItem('surviveUser', JSON.stringify({ name, scene: 'start' }));
+    const gender = document.getElementById('gender').value;
+    const lang = document.getElementById('lang').value;
+    const user = {
+        name,
+        gender,
+        lang,
+        scene: 'start',
+        stats: { money: 10, power: 5, social: 5, hunger: 0 }
+    };
+    localStorage.setItem('surviveUser', JSON.stringify(user));
     window.location.href = 'game.html';
 }
 

--- a/style.css
+++ b/style.css
@@ -1,3 +1,5 @@
 body { font-family: sans-serif; margin: 20px; background:#f5f5f5; }
 button { margin: 5px; }
 #text { margin: 20px 0; }
+#stats { margin: 10px 0; }
+#stats span { margin-right: 10px; }


### PR DESCRIPTION
## Summary
- allow player to choose gender and language at start
- translate game text to Turkish (default) and English
- show emoji visuals for each scene and display player stats
- track money, power, social circle and hunger as player progresses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68454f4667dc8323a8d6b2c7c2ba6702